### PR TITLE
Screenshot enhancement

### DIFF
--- a/src/play_clj/core.clj
+++ b/src/play_clj/core.clj
@@ -6,8 +6,9 @@
             InputMultiplexer InputProcessor Net Screen]
            [com.badlogic.gdx.audio Sound]
            [com.badlogic.gdx.assets AssetManager]
+           [com.badlogic.gdx.files FileHandle]
            [com.badlogic.gdx.graphics Camera Color GL20 OrthographicCamera
-            PerspectiveCamera Pixmap Texture VertexAttributes$Usage]
+            PerspectiveCamera Pixmap Pixmap$Format PixmapIO Texture VertexAttributes$Usage]
            [com.badlogic.gdx.graphics.g2d SpriteBatch]
            [com.badlogic.gdx.graphics.g3d ModelBatch]
            [com.badlogic.gdx.graphics.glutils ShapeRenderer]
@@ -26,7 +27,7 @@
            [com.badlogic.gdx.scenes.scene2d Actor Stage]
            [com.badlogic.gdx.scenes.scene2d.utils ActorGestureListener Align
             ChangeListener ClickListener DragListener FocusListener]
-           [com.badlogic.gdx.utils Timer$Task]
+           [com.badlogic.gdx.utils ScreenUtils Timer$Task]
            [play_clj.entities ShapeEntity]))
 
 (load "core_basics")

--- a/src/play_clj/core_utils.clj
+++ b/src/play_clj/core_utils.clj
@@ -7,6 +7,35 @@
   [& body]
   `(app! :post-runnable (fn [] ~@body)))
 
+(defn new-file!
+  "Creates a new [File](http://docs.oracle.com/javase/7/docs/api/java/io/File.html)"
+  ([name extension]
+     (new-file! "./" name extension))
+  ([path name extension]
+      (java.io.File. (str path name extension))))
+
+(defn capture-screen!
+  "Returns a [Pixmap](http://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/graphics/Pixmap.html) that contains a capture of the current screen.
+   Note that you must call [dispose](http://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/graphics/Pixmap.html#dispose) on the Pixmap or you will cause a memory leak on the native heap.
+   screenshot! captures and disposes the Pixmap automatically."
+  []
+  (let [pixmap (Pixmap. (game :width) (game :height) (Pixmap$Format/RGBA8888))
+        pixel-data (ScreenUtils/getFrameBufferPixels true)
+        pixels (.getPixels pixmap)]
+    (doto pixels
+      (.clear)
+      (.put pixel-data)
+      (.position))
+    pixmap))
+
+(defn screenshot!
+  "Captures a screenshot and writes it to disk."
+  []
+  (let [pixmap (capture-screen!)
+        handle (FileHandle. (new-file! (str (System/currentTimeMillis)) ".png"))]
+    (do (PixmapIO/writePNG handle pixmap)
+        (.dispose pixmap))))
+
 ; static fields
 
 (defmacro scaling


### PR DESCRIPTION
See #10 and [screenshot proof of concept](https://gist.github.com/anthonyurena/10069110). I figured it out!
I wasn't sure where this would go in the project (if at all) or how it would be integrated, but here's my best guess.

I'm 100% willing to clean things up and make a complete overhaul of it. The `screenshot!` function in particular could use some work in terms of flexibility. I figured it would be beneficial to open a pr since #10 is sort of irrelevant now that I've figured out what I wanted to accomplish.

The proof of concept (and code in the pr) can be used from the repl with the play-clj-example games:
![taking a screenshot from the repl](https://cloud.githubusercontent.com/assets/5338832/2639622/0904d892-becf-11e3-9518-bc1add05580c.png)

**Result**
![1396928162581](https://cloud.githubusercontent.com/assets/5338832/2639629/37e6771a-becf-11e3-8c8c-9a7200eac8ca.png)
