### PR TITLE
Remove whitespaces from core.clj template

### DIFF
--- a/template/src/leiningen/new/play_clj/core.clj
+++ b/template/src/leiningen/new/play_clj/core.clj
@@ -7,7 +7,7 @@
   (fn [screen entities]
     (update! screen :renderer (stage))
     (label "Hello world!" (color :white)))
-  
+
   :on-render
   (fn [screen entities]
     (clear!)


### PR DESCRIPTION
This removes unnecessary whitespace from the leiningen template for core.clj.
