### PR TITLE
Fixed issue with position! screen Vector3 IllegalAccessError

### DIFF
--- a/src/play_clj/core_cameras.clj
+++ b/src/play_clj/core_cameras.clj
@@ -165,8 +165,7 @@ of the camera will be set."
   "Sets the position of `object`. If `object` is a screen, the position of the
 camera will be set."
   ([object vec-3]
-    (let [^Camera camera (u/get-obj object :camera)]
-      (set! (. camera position) vec-3)))
+    (position! object (x vec-3) (y vec-3) (z vec-3)))
   ([object x-val y-val]
     (position! object x-val y-val nil))
   ([object x-val y-val z-val]


### PR DESCRIPTION
Previously the code would try to directly set the position vector with the new Vector3 that it was passed. The problem is that the position vector is final. 

```java
/** the position of the camera **/
public final Vector3 position = new Vector3();
```
I looked for a position function in the [Camera.java](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/graphics/Camera.java) file for libgdx but didn't see any. They had translate but that was not an absolute position but relative to where the camera currently is. I just forwarded the call to (postition! object x y z).