### PR TITLE
Added the ability to get the up vector of a camera. 

### DIFF
--- a/src/play_clj/core_cameras.clj
+++ b/src/play_clj/core_cameras.clj
@@ -186,6 +186,11 @@ camera will be set."
     (.lookAt camera x y z)
     (.update camera)))
 
+(defn up [screen]
+  "Returns the up vector of the camera in `screen`."
+  (let [^Camera camera (u/get-obj screen :camera)]
+    (. camera up)))
+
 (defn near
   "Returns the near clipping plane distance of the camera in `screen`."
   [screen]


### PR DESCRIPTION
I am working on a First Person 3D controller based off of [this](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/graphics/g3d/utils/FirstPersonCameraController.java) example. I just implemented the getting of the camera up vector. I didn't implement the  setter because I didn't need it but if you want that before merging tell me.