### PR TITLE
draw map layers in their correct order when using :with or :without

### DIFF
--- a/src/play_clj/core_graphics.clj
+++ b/src/play_clj/core_graphics.clj
@@ -526,6 +526,7 @@ specify which layers to render with or without.
                                               (set layer-names))
              (u/throw-key-not-found k))
            (map #(.indexOf ^java.util.List all-layer-names %))
+           (sort)
            int-array
            (.render renderer)))
     (.render renderer))


### PR DESCRIPTION
Hi.
Really enjoying play-clj via Nightmod with my daughter.
This small change makes sure map layers are drawn in the right order. (My path disappeared under the grass layer.)
