### PR TITLE
avoid reflection for performance

### DIFF
--- a/src/play_clj/core.clj
+++ b/src/play_clj/core.clj
@@ -524,7 +524,7 @@ keywords and functions in pairs."
                              (doseq [[_ listener] (:input-listeners @screen)]
                                (add-input! listener))
                              (when-let [renderer (:renderer @screen)]
-                               (when (isa? (type renderer) Stage)
+                               (when (instance? Stage renderer)
                                  (add-input! renderer)))))
                          (render [this d] (run-fn! :render d))
                          (hide [this] (run-fn! :hide))

--- a/src/play_clj/core_cameras.clj
+++ b/src/play_clj/core_cameras.clj
@@ -94,8 +94,8 @@ remains in tact.
 of the camera will be returned."
   [object]
   (cond
-    (isa? (type object) Vector2) (. ^Vector2 object x)
-    (isa? (type object) Vector3) (. ^Vector3 object x)
+    (instance? Vector2 object) (. ^Vector2 object x)
+    (instance? Vector3 object) (. ^Vector3 object x)
     :else (let [^Camera camera (u/get-obj object :camera)]
             (. (. camera position) x))))
 
@@ -104,9 +104,9 @@ of the camera will be returned."
 of the camera will be set."
   [object x-val]
   (cond
-    (isa? (type object) Vector2) (let [^Vector2 v object]
+    (instance? Vector2 object) (let [^Vector2 v object]
                                    (.set v x-val (. v y)))
-    (isa? (type object) Vector3) (let [^Vector3 v object]
+    (instance? Vector3 object) (let [^Vector3 v object]
                                    (.set v x-val (. v y) (. v z)))
     :else (let [^Camera camera (u/get-obj object :camera)]
             (set! (. (. camera position) x) x-val)
@@ -117,8 +117,8 @@ of the camera will be set."
 of the camera will be returned."
   [object]
   (cond
-    (isa? (type object) Vector2) (. ^Vector2 object y)
-    (isa? (type object) Vector3) (. ^Vector3 object y)
+    (instance? Vector2 object) (. ^Vector2 object y)
+    (instance? Vector3 object) (. ^Vector3 object y)
     :else (let [^Camera camera (u/get-obj object :camera)]
             (. (. camera position) y))))
 
@@ -127,9 +127,9 @@ of the camera will be returned."
 of the camera will be set."
   [object y-val]
   (cond
-    (isa? (type object) Vector2) (let [^Vector2 v object]
+    (instance? Vector2 object) (let [^Vector2 v object]
                                    (.set v (. v x) y-val))
-    (isa? (type object) Vector3) (let [^Vector3 v object]
+    (instance? Vector3 object) (let [^Vector3 v object]
                                    (.set v (. v x) y-val (. v z)))
     :else (let [^Camera camera (u/get-obj object :camera)]
             (set! (. (. camera position) y) y-val)
@@ -140,7 +140,7 @@ of the camera will be set."
 of the camera will be returned."
   [object]
   (cond
-    (isa? (type object) Vector3) (. ^Vector3 object z)
+    (instance? Vector3 object) (. ^Vector3 object z)
     :else (let [^Camera camera (u/get-obj object :camera)]
             (. (. camera position) z))))
 
@@ -149,7 +149,7 @@ of the camera will be returned."
 of the camera will be set."
   [object z-val]
   (cond
-    (isa? (type object) Vector3) (let [^Vector3 v object]
+    (instance? Vector3 object) (let [^Vector3 v object]
                                    (.set v (. v x) (. v y) z-val))
     :else (let [^Camera camera (u/get-obj object :camera)]
             (set! (. (. camera position) z) z-val)

--- a/src/play_clj/core_graphics.clj
+++ b/src/play_clj/core_graphics.clj
@@ -121,7 +121,7 @@ Normally, you don't need to use this directly."
         (-> ^BatchTiledMapRenderer (u/get-obj screen :renderer)
             .getMap
             .getLayers
-            (.get layer)))))
+            (.get (str layer))))))
 
 (defmacro tiled-map-layer
   "Returns a [TiledMapTileLayer](http://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.html)

--- a/src/play_clj/core_graphics.clj
+++ b/src/play_clj/core_graphics.clj
@@ -87,7 +87,7 @@ complicated shapes. If you use `assoc` to set the overall :x and :y of the
 (defn shape?
   "Returns true if `entity` is a `shape`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) ShapeRenderer))
+  (instance? ShapeRenderer (u/get-obj entity :object)))
 
 ; tiled maps
 
@@ -116,7 +116,7 @@ Normally, you don't need to use this directly."
   ([width height tile-width tile-height]
     (TiledMapTileLayer. width height tile-width tile-height))
   ([screen layer]
-    (if (isa? (type layer) MapLayer)
+    (if (instance? MapLayer layer)
         layer
         (-> ^BatchTiledMapRenderer (u/get-obj screen :renderer)
             .getMap
@@ -545,9 +545,9 @@ specify which layers to render with or without.
     (render! screen entities)"
   ([{:keys [renderer] :as screen}]
     (cond
-      (isa? (type renderer) BatchTiledMapRenderer)
+      (instance? BatchTiledMapRenderer renderer)
       (render-map! screen)
-      (isa? (type renderer) Stage)
+      (instance? Stage renderer)
       (render-stage! screen)))
   ([screen entities]
     (render! screen)
@@ -562,8 +562,8 @@ specify which layers to render with or without.
 
 (defn ^:private isometric?
   [{:keys [renderer] :as screen}]
-  (or (isa? (type renderer) IsometricTiledMapRenderer)
-      (isa? (type renderer) IsometricStaggeredTiledMapRenderer)))
+  (or (instance? IsometricTiledMapRenderer renderer)
+      (instance? IsometricStaggeredTiledMapRenderer renderer)))
 
 (defn ^:private split-layer
   [screen layer-name]

--- a/src/play_clj/core_listeners.clj
+++ b/src/play_clj/core_listeners.clj
@@ -193,7 +193,7 @@ in the `screen`."
         (.update (game :width) (game :height) true))))
   ([{:keys [^Stage renderer ui-listeners]} entities]
      (let [current (->> (map :object entities)
-                        (filter #(isa? (type %) Actor))
+                        (filter #(instance? Actor %))
                         (into #{}))
            new-actors (apply disj current (.getActors renderer))]
        (doseq [^Actor a (.getActors renderer)
@@ -212,11 +212,11 @@ in the `screen`."
 
 (defn ^:private update-screen!
   ([{:keys [renderer world] :as screen}]
-    (when (isa? (type renderer) Stage)
+    (when (instance? Stage renderer)
       (update-stage! screen))
     (update-physics! screen))
   ([{:keys [renderer world] :as screen} entities]
-    (when (isa? (type renderer) Stage)
+    (when (instance? Stage renderer)
       (update-stage! screen entities))
     (update-physics! screen entities)
     entities))

--- a/src/play_clj/core_utils.clj
+++ b/src/play_clj/core_utils.clj
@@ -30,7 +30,7 @@ be passed down to all the internal entities unless they already have those keys.
 (defn bundle?
   "Returns true if `entity` is a `bundle`."
   [entity]
-  (isa? (type entity) BundleEntity))
+  (instance? BundleEntity entity))
 
 (defn screenshot!
   "Captures a screenshot and either returns it as a `pixmap` or saves it to the

--- a/src/play_clj/entities.clj
+++ b/src/play_clj/entities.clj
@@ -1,6 +1,6 @@
 (ns play-clj.entities
   (:import [com.badlogic.gdx Gdx Graphics]
-           [com.badlogic.gdx.graphics Camera]
+           [com.badlogic.gdx.graphics Camera Color]
            [com.badlogic.gdx.graphics.g2d Batch NinePatch ParticleEffect
             TextureRegion]
            [com.badlogic.gdx.graphics.g3d Environment ModelBatch ModelInstance]
@@ -21,13 +21,15 @@
 
 (defrecord TextureEntity [object] Entity
   (draw! [{:keys [^TextureRegion object x y width height
-                  scale-x scale-y angle origin-x origin-y]}
+                  scale-x scale-y angle origin-x origin-y color]}
           _
           batch]
     (let [x (float (or x 0))
           y (float (or y 0))
           width (float (or width (.getRegionWidth object)))
           height (float (or height (.getRegionHeight object)))]
+      (when-let [[r g b a] color]
+        (.setColor ^Batch batch r g b a))
       (if (or scale-x scale-y angle)
         (let [scale-x (float (or scale-x 1))
               scale-y (float (or scale-y 1))
@@ -36,7 +38,9 @@
               angle (float (or angle 0))]
           (.draw ^Batch batch object x y origin-x origin-y width height
             scale-x scale-y angle))
-        (.draw ^Batch batch object x y width height)))))
+        (.draw ^Batch batch object x y width height))
+      (when color
+        (.setColor ^Batch batch Color/WHITE)))))
 
 (defrecord NinePatchEntity [object] Entity
   (draw! [{:keys [^NinePatch object x y width height]} _ batch]

--- a/src/play_clj/g2d.clj
+++ b/src/play_clj/g2d.clj
@@ -40,11 +40,11 @@
       (-> (or (u/load-asset arg Texture)
               (Texture. ^String arg))
           TextureRegion.)
-      (isa? (type arg) Pixmap)
+      (instance? Pixmap arg)
       (-> ^Pixmap arg Texture. TextureRegion.)
-      (isa? (type arg) Texture)
+      (instance? Texture arg)
       (-> ^Texture arg TextureRegion.)
-      (isa? (type arg) TextureEntity)
+      (instance? TextureEntity arg)
       (-> ^TextureRegion (:object arg) TextureRegion.)
       :else
       arg)))
@@ -79,7 +79,7 @@
 (defn texture?
   "Returns true if `entity` is a `texture`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) TextureRegion))
+  (instance? TextureRegion (u/get-obj entity :object)))
 
 ; nine-patch
 
@@ -92,7 +92,7 @@
               (Texture. ^String arg))
           TextureRegion.
           NinePatch.)
-      (isa? (type arg) NinePatchEntity)
+      (instance? NinePatchEntity arg)
       (NinePatch. (:object arg))
       (map? arg)
       (let [{:keys [region left right top bottom]} arg]
@@ -121,7 +121,7 @@
 (defn nine-patch?
   "Returns true if `entity` is a `nine-patch`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) NinePatch))
+  (instance? NinePatch (u/get-obj entity :object)))
 
 ; particle-effect
 
@@ -154,7 +154,7 @@
 (defn particle-effect?
   "Returns true if `entity` is a `particle-effect`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) ParticleEffect))
+  (instance? ParticleEffect (u/get-obj entity :object)))
 
 ; texture-atlas
 

--- a/src/play_clj/g3d.clj
+++ b/src/play_clj/g3d.clj
@@ -96,9 +96,9 @@ object created by an external application.
        (cond
          (string? arg1#)
          (ModelInstance. (model* arg1#))
-         (isa? (type arg1#) ModelEntity)
+         (instance? ModelEntity arg1#)
          (ModelInstance. (. ^ModelInstance (:object arg1#) model) ~@(rest args))
-         (isa? (type arg1#) ModelData)
+         (instance? ModelData arg1#)
          (ModelInstance. ^Model (Model. arg1# ~@(rest args)))
          :else
          (ModelInstance. arg1# ~@(rest args))))))
@@ -112,7 +112,7 @@ object created by an external application.
 (defn model?
   "Returns true if `entity` is a `model`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) ModelInstance))
+  (instance? ModelInstance (u/get-obj entity :object)))
 
 ; model-builder
 

--- a/src/play_clj/g3d_physics.clj
+++ b/src/play_clj/g3d_physics.clj
@@ -130,9 +130,9 @@
     (add-body! screen (rigid-body info))"
   [screen body]
   (cond
-    (isa? (type (:object body)) btRigidBody)
+    (instance? btRigidBody (:object body))
     (bullet-3d! screen :add-rigid-body (:object body))
-    (isa? (type (:object body)) btSoftBody)
+    (instance? btSoftBody (:object body))
     (bullet-3d! screen :add-soft-body (:object body)))
   body)
 
@@ -290,7 +290,7 @@ such as :on-begin-contact."
   (doseq [e entities]
     (let [object (u/get-obj e :object)
           body (u/get-obj e :body)]
-      (when (and object (isa? (type (:object body)) btRigidBody))
+      (when (and object (instance? btRigidBody (:object body)))
         (when-not (rigid-body! e :get-motion-state)
           (->> (proxy [btMotionState] []
                  (getWorldTransform [world-t])
@@ -302,9 +302,9 @@ such as :on-begin-contact."
     (doseq [^btCollisionObject body (get-bodies screen)]
       (when-not (some #(= body (-> % :body :object)) entities)
         (cond
-          (isa? (type body) btRigidBody)
+          (instance? btRigidBody body)
           (bullet-3d! screen :remove-rigid-body body)
-          (isa? (type body) btSoftBody)
+          (instance? btSoftBody body)
           (bullet-3d! screen :remove-soft-body body))
         (.dispose body)))))
 

--- a/src/play_clj/ui.clj
+++ b/src/play_clj/ui.clj
@@ -179,7 +179,7 @@ based on the file at `path`.
 (defn actor?
   "Returns true if `entity` is an actor."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Actor))
+  (instance? Actor (u/get-obj entity :object)))
 
 ; check-box
 
@@ -206,7 +206,7 @@ based on the file at `path`.
 (defn check-box?
   "Returns true if `entity` is a `check-box`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) CheckBox))
+  (instance? CheckBox (u/get-obj entity :object)))
 
 ; container
 
@@ -231,7 +231,7 @@ based on the file at `path`.
 (defn container?
   "Returns true if `entity` is a `container`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Container))
+  (instance? Container (u/get-obj entity :object)))
 
 ; dialog
 
@@ -258,7 +258,7 @@ based on the file at `path`.
 (defn dialog?
   "Returns true if `entity` is a `dialog`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Dialog))
+  (instance? Dialog (u/get-obj entity :object)))
 
 ; horizontal
 
@@ -283,7 +283,7 @@ based on the file at `path`.
 (defn horizontal?
   "Returns true if `entity` is a `horizontal`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) HorizontalGroup))
+  (instance? HorizontalGroup (u/get-obj entity :object)))
 
 ; image
 
@@ -316,7 +316,7 @@ based on the file at `path`.
 (defn image?
   "Returns true if `entity` is an `image`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Image))
+  (instance? Image (u/get-obj entity :object)))
 
 ; image-button
 
@@ -343,7 +343,7 @@ based on the file at `path`.
 (defn image-button?
   "Returns true if `entity` is an `image-button`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) ImageButton))
+  (instance? ImageButton (u/get-obj entity :object)))
 
 ; image-text-button
 
@@ -372,14 +372,14 @@ based on the file at `path`.
 (defn image-text-button?
   "Returns true if `entity` is a `image-text-button`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) ImageTextButton))
+  (instance? ImageTextButton (u/get-obj entity :object)))
 
 ; label
 
 (defn label*
   [^String text arg]
   (ActorEntity.
-    (if (isa? (type arg) Color)
+    (if (instance? Color arg)
       (Label. text (style :label (g2d/bitmap-font) arg))
       (Label. text arg))))
 
@@ -402,7 +402,7 @@ based on the file at `path`.
 (defn label?
   "Returns true if `entity` is a `label`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Label))
+  (instance? Label (u/get-obj entity :object)))
 
 ; scroll-pane
 
@@ -429,7 +429,7 @@ based on the file at `path`.
 (defn scroll-pane?
   "Returns true if `entity` is a `scroll-pane`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) ScrollPane))
+  (instance? ScrollPane (u/get-obj entity :object)))
 
 ; select-box
 
@@ -461,7 +461,7 @@ based on the file at `path`.
 (defn select-box?
   "Returns true if `entity` is a `select-box`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) SelectBox))
+  (instance? SelectBox (u/get-obj entity :object)))
 
 ; slider
 
@@ -491,7 +491,7 @@ based on the file at `path`.
 (defn slider?
   "Returns true if `entity` is a `slider`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Slider))
+  (instance? Slider (u/get-obj entity :object)))
 
 ; stack
 
@@ -516,7 +516,7 @@ based on the file at `path`.
 (defn stack?
   "Returns true if `entity` is a `stack`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Stack))
+  (instance? Stack (u/get-obj entity :object)))
 
 ; table
 
@@ -541,7 +541,7 @@ based on the file at `path`.
 (defn table?
   "Returns true if `entity` is a `table`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Table))
+  (instance? Table (u/get-obj entity :object)))
 
 ; text-button
 
@@ -568,7 +568,7 @@ based on the file at `path`.
 (defn text-button?
   "Returns true if `entity` is a `text-button`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) TextButton))
+  (instance? TextButton (u/get-obj entity :object)))
 
 ; text-field
 
@@ -595,7 +595,7 @@ based on the file at `path`.
 (defn text-field?
   "Returns true if `entity` is a `text-field`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) TextField))
+  (instance? TextField (u/get-obj entity :object)))
 
 ; tree
 
@@ -622,7 +622,7 @@ based on the file at `path`.
 (defn tree?
   "Returns true if `entity` is a `tree`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Tree))
+  (instance? Tree (u/get-obj entity :object)))
 
 ; vertical
 
@@ -647,7 +647,7 @@ based on the file at `path`.
 (defn vertical?
   "Returns true if `entity` is a `vertical`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) VerticalGroup))
+  (instance? VerticalGroup (u/get-obj entity :object)))
 
 ; window
 
@@ -674,7 +674,7 @@ based on the file at `path`.
 (defn window?
   "Returns true if `entity` is a `window`."
   [entity]
-  (isa? (type (u/get-obj entity :object)) Window))
+  (instance? Window (u/get-obj entity :object)))
 
 ; listeners
 


### PR DESCRIPTION
Hi, these showed up in some profiling i did: `isa?` (and its underlying `Class.getInterfaces`) and reflection on `.get` in `tiled-map-renderer*`.