### PR TITLE
listeners in correct order

### DIFF
--- a/src/play_clj/core.clj
+++ b/src/play_clj/core.clj
@@ -520,7 +520,7 @@ keywords and functions in pairs."
                   (show [this]
                     (input! :set-input-processor (InputMultiplexer.))
                     (run-fn! :show)
-                    (doseq [{:keys [screen]} screen-objects]
+                    (doseq [{:keys [screen]} (reverse screen-objects)]
                       (doseq [[_ listener] (:input-listeners @screen)]
                         (add-input! listener))
                       (when-let [renderer (:renderer @screen)]


### PR DESCRIPTION
Button in screen 2 does not work if e.g. tap listener is enabled in screen 1. But screen 2 is ontop of screen 1 and should get the event first.
