### PR TITLE
Fix for texture misalignment with relation to Box2D Shapes

### DIFF
--- a/src/play_clj/entities.clj
+++ b/src/play_clj/entities.clj
@@ -21,8 +21,7 @@
 
 (defrecord TextureEntity [object] Entity
   (draw! [{:keys [^TextureRegion object x y width height
-                  scale-x scale-y angle origin-x origin-y color
-                  translate-x translate-y]}
+                  scale-x scale-y angle color translate-x translate-y]}
           _
           batch]
     (let [x (float (or x 0))
@@ -36,10 +35,8 @@
       (if (or scale-x scale-y angle)
         (let [scale-x (float (or scale-x 1))
               scale-y (float (or scale-y 1))
-              origin-x (float (or origin-x (/ width 2)))
-              origin-y (float (or origin-y (/ height 2)))
               angle (float (or angle 0))]
-          (.draw ^Batch batch object (+ x translate-x) (+ y translate-y) origin-x origin-y width height
+          (.draw ^Batch batch object (+ x translate-x) (+ y translate-y) 0 0 width height
             scale-x scale-y angle))
         (.draw ^Batch batch object (+ x translate-x) (+ y translate-y) width height))
       (when color

--- a/src/play_clj/entities.clj
+++ b/src/play_clj/entities.clj
@@ -21,11 +21,14 @@
 
 (defrecord TextureEntity [object] Entity
   (draw! [{:keys [^TextureRegion object x y width height
-                  scale-x scale-y angle origin-x origin-y color]}
+                  scale-x scale-y angle origin-x origin-y color
+                  translate-x translate-y]}
           _
           batch]
     (let [x (float (or x 0))
           y (float (or y 0))
+          translate-x (float (or translate-x 0))
+          translate-y (float (or translate-y 0))
           width (float (or width (.getRegionWidth object)))
           height (float (or height (.getRegionHeight object)))]
       (when-let [[r g b a] color]
@@ -36,11 +39,12 @@
               origin-x (float (or origin-x (/ width 2)))
               origin-y (float (or origin-y (/ height 2)))
               angle (float (or angle 0))]
-          (.draw ^Batch batch object x y origin-x origin-y width height
+          (.draw ^Batch batch object (+ x translate-x) (+ y translate-y) origin-x origin-y width height
             scale-x scale-y angle))
-        (.draw ^Batch batch object x y width height))
+        (.draw ^Batch batch object (+ x translate-x) (+ y translate-y) width height))
       (when color
         (.setColor ^Batch batch Color/WHITE)))))
+
 
 (defrecord NinePatchEntity [object] Entity
   (draw! [{:keys [^NinePatch object x y width height]} _ batch]


### PR DESCRIPTION
Textures should not have the extra translation currently provided with the origin-x and origin-y values.  A regular ShapeEntity does not use this for rendering, nor should textures.

Additionally, textures and circle shapes do not treat their respective origins the same - a circle is in the middle, whereas the texture uses lower/left as its origin.  This allows adding translate-x and translate-y keys into the entity map for textures to be aligned with their respective Box2D shape.

