### PR TITLE
Fix for texture misalignment with relation to Box2D Shapes

### DIFF
--- a/src/play_clj/entities.clj
+++ b/src/play_clj/entities.clj
@@ -21,7 +21,7 @@
 
 (defrecord TextureEntity [object] Entity
   (draw! [{:keys [^TextureRegion object x y width height
-                  scale-x scale-y angle origin-x origin-y color]}
+                  scale-x scale-y angle color]}
           _
           batch]
     (let [x (float (or x 0))
@@ -33,10 +33,8 @@
       (if (or scale-x scale-y angle)
         (let [scale-x (float (or scale-x 1))
               scale-y (float (or scale-y 1))
-              origin-x (float (or origin-x (/ width 2)))
-              origin-y (float (or origin-y (/ height 2)))
               angle (float (or angle 0))]
-          (.draw ^Batch batch object x y origin-x origin-y width height
+          (.draw ^Batch batch object x y 0 0 width height
             scale-x scale-y angle))
         (.draw ^Batch batch object x y width height))
       (when color


### PR DESCRIPTION
Textures should not have the extra translation currently provided with the origin-x and origin-y values, as this will skew the mapping if rotation occurs.  A regular ShapeEntity does not use this for rendering, nor should textures.
