### PR TITLE
Fixes for issues #103, #104 and #105

### DIFF
--- a/src/play_clj/core_basics.clj
+++ b/src/play_clj/core_basics.clj
@@ -107,7 +107,7 @@
     :point-y (game :y arg)
     (u/throw-key-not-found k)))
 
-(defmacro key-code
+(defn key-code
   "Returns a static field from [Input.Keys](http://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/Input.Keys.html).
 
     (key-code :a)

--- a/src/play_clj/core_basics.clj
+++ b/src/play_clj/core_basics.clj
@@ -123,7 +123,7 @@
   [k]
   `(input! :is-key-pressed (key-code ~k)))
 
-(defmacro button-code
+(defn button-code
   "Returns a static field from [Input.Buttons](http://libgdx.badlogicgames.com/nightlies/docs/api/com/badlogic/gdx/Input.Buttons.html).
 
     (button-code :left)"


### PR DESCRIPTION
Benefits of using defmacro instead of defn:
ensures that the return value of key-code and button-code are numbers.

Drawbacks of using defmacro instead of defn:
the key-code and button-code macros accept (and parse!) symbols. For instance:
```
(= (key-code a) (key-code :a))
true
```
such that wrapping the macro in a function is impossible:
`(map (fn [a] (key-code a)) [:a :b :c :d])`

--------------------------
Compare the implementations of defn with defmacro:
```
(key-code :w)
51
```

Using defn instead of defmacro allows for composability, but the return value is not a number:
```
(key-code :w)
com.badlogic.gdx.Input$Keys/W
```

I submit that this is the more desirable behavior. For one thing, we can tell at a glance what the value is-- we know that it is associated with the W key-- 51 is just an arbitrary encoding. Equality semantics are still satisfied.

This would be erronous with the defmacro implementation of key-code, but valid for the defn implementation:
```
(clojure.set/superset?
        #{(key-code :a) (key-code :b) (key-code :c)}
        (into #{} (map (fn [a] (key-code a))) #{:a :b}))
```